### PR TITLE
Reorder textbox open event, and the talk-after script call

### DIFF
--- a/engine/events/trainer_scripts.asm
+++ b/engine/events/trainer_scripts.asm
@@ -15,10 +15,10 @@ SeenByTrainerScript::
 	applymovementlasttalked wMovementBuffer
 	writeobjectxy LAST_TALKED
 	faceobject PLAYER, LAST_TALKED
+	opentext
 	sjump StartBattleWithMapTrainerScript
 
 StartBattleWithMapTrainerScript:
-	opentext
 	trainertext TRAINERTEXT_SEEN
 	waitbutton
 	closetext
@@ -26,8 +26,8 @@ StartBattleWithMapTrainerScript:
 	startbattle
 	reloadmapafterbattle
 	trainerflagaction SET_FLAG
-	loadmem wRunningTrainerBattleScript, -1
 	scripttalkafter
+	loadmem wRunningTrainerBattleScript, -1
 	end
 
 AlreadyBeatenTrainerScript:


### PR DESCRIPTION
This change fix opening the text box when a trainer is talked to.  When a battle is complete, the after-battle text will now also correctly show.